### PR TITLE
ci: no need to install later linux-headers anymore

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,11 +25,7 @@ jobs:
     - name: Run tests (Linux 4.14 support)
       run: cargo test --verbose --features linux4_14
     - name: Run tests (Linux 5.7 support)
-      run:
-        sudo apt update &&
-        sudo apt install -y linux-headers-5.11.0-25-generic &&
-        export LINUX_HEADERS=/usr/src/linux-headers-5.11.0-25-generic &&
-        cargo test --verbose --features linux5_7
+      run: cargo test --verbose --features linux5_7
 
   audit:
 


### PR DESCRIPTION
ubuntu-latest image upgraded to 22.04 since last run. this means its running on kernel 5.15, so the included headers should be new enough to build the 5.7 feature.