### PR TITLE
patch version bump of both crates for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
userfaultfd-sys just had the repo metadata updated userfaultfd had the repo metadata, plus upgrade to nix 0.26 https://github.com/bytecodealliance/userfaultfd-rs/pull/41