### PR TITLE
Update bindgen to the latest (0.65.1)

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 cfg-if = "^1.0.0"
 
 [build-dependencies]
-bindgen = { version = "^0.60.1", default-features = false, features = ["runtime"]  }
+bindgen = { version = "^0.65.1", default-features = false, features = ["runtime"]  }
 cc = "1.0"
 
 [features]


### PR DESCRIPTION
userfaultfd-sys fails to build <linux/userfaultfd.h> header file with newer clang. Newer bindgen have fix for it
https://github.com/rust-lang/rust-bindgen/pull/2319