### PR TITLE
userfaultfd-sys: release 0.4.4

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The update does not change the public interface.

PR #44 Update bindgen to the latest (0.65.1)