### PR TITLE
Update bitflags to 2.2.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - Added `Uffd::read_events` that can read multiple events from the userfaultfd file descriptor.
+- Updated `bitflags` dependency to `2.2.1`.
 
 ### 0.3.1 (2021-02-17)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bytecodealliance/userfaultfd-rs"
 readme = "README.md"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "2.2.1"
 cfg-if = "^1.0.0"
 libc = "0.2.65"
 nix = "0.26"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,7 @@ cfg_if::cfg_if! {
     if #[cfg(any(feature = "linux5_7", feature = "linux4_14"))] {
         bitflags! {
             /// Used with `UffdBuilder` to determine which features are available in the current kernel.
+            #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct FeatureFlags: u64 {
                 const PAGEFAULT_FLAG_WP = raw::UFFD_FEATURE_PAGEFAULT_FLAG_WP;
                 const EVENT_FORK = raw::UFFD_FEATURE_EVENT_FORK;
@@ -23,6 +24,7 @@ cfg_if::cfg_if! {
     } else {
         bitflags! {
             /// Used with `UffdBuilder` to determine which features are available in the current kernel.
+            #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct FeatureFlags: u64 {
                 const PAGEFAULT_FLAG_WP = raw::UFFD_FEATURE_PAGEFAULT_FLAG_WP;
                 const EVENT_FORK = raw::UFFD_FEATURE_EVENT_FORK;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ impl FromRawFd for Uffd {
 
 bitflags! {
     /// The registration mode used when registering an address range with `Uffd`.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct RegisterMode: u64 {
         /// Registers the range for missing page faults.
         const MISSING = raw::UFFDIO_REGISTER_MODE_MISSING;
@@ -359,6 +360,7 @@ impl Uffd {
 
 bitflags! {
     /// Used with `UffdBuilder` and `Uffd::register()` to determine which operations are available.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct IoctlFlags: u64 {
         const REGISTER = 1 << raw::_UFFDIO_REGISTER;
         const UNREGISTER = 1 << raw::_UFFDIO_UNREGISTER;


### PR DESCRIPTION
bitflags no longer automatically derives traits so we need to explicitly derive them.