### PR TITLE
bump userfaultfd crate version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The diff from 0.5.1 is a major version bump of the bitflags dep: https://github.com/bytecodealliance/userfaultfd-rs/pull/47

Since bitflags is a proc-macro which generates public impls in the userfaultfd crate, we are treating this update as breaking compatibility, hence bumping the minor 0.x version.