### PR TITLE
Fix failure in Github action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,23 +9,49 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # ubuntu-latest runs a recent kernel with /dev/userfaultfd support whereas
+    # ubuntu-20.04 has a 5.15 kernel. We run the job in both, so we can test
+    # both paths for creating the file descriptor, i.e. /dev/userfaultfd ioctl
+    # and userfaultfd syscall.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ ubuntu-latest, ubuntu-20.04 ]
 
     steps:
     - uses: actions/checkout@v2
+
+    # Keep this step, so that we can check that the Linux kernel is the one we
+    # expect, depending on the runner kernel.
+    - name: Check Linux version
+      run: uname -r
+
+    # /dev/userfaultfd is only present on ubuntu-latest.
+    - name: Setup access to /dev/userfaultfd
+      if: ${{ matrix.runner == 'ubuntu-latest' }}
+      run: sudo setfacl -m u:${USER}:rw /dev/userfaultfd
+
     - name: Build
       run: cargo build --verbose
-
-    # The github ubuntu-latest is now on linux 5.11 kernel,
-    # so we can test the crate with support for each of the
-    # kernel featuresets:
 
     - name: Run tests (Linux 4.11 support)
       run: cargo test --verbose
     - name: Run tests (Linux 4.14 support)
       run: cargo test --verbose --features linux4_14
+
     - name: Run tests (Linux 5.7 support)
+      if: ${{ matrix.runner == 'ubuntu-latest' }}
       run: cargo test --verbose --features linux5_7
+
+    # On ubuntu-20.04 runner we need to make sure we have the proper kernel
+    # headers for building the correct bindings
+    - name: Run tests (Linux 5.7 support)
+      if: ${{ matrix.runner == 'ubuntu-20.04' }}
+      run:
+        sudo apt update &&
+        sudo apt install -y linux-headers-5.11.0-25-generic &&
+        export LINUX_HEADERS=/usr/src/linux-headers-5.11.0-25-generic &&
+        cargo test --verbose --features linux5_7
 
   audit:
 


### PR DESCRIPTION
It looks as if when we opened #56 `ubuntu-latest` Github Actions runner image did not ship a kernel that was >= 6.1. So, the code that created the userfault file descriptor did not use the ioctl to `/dev/userfaultfd` path and it always succeeded (using the `userfaultfd` syscall).

It seems that at some point afterwards `ubuntu-latest` came with an update kernel (6.2) and it triggered the `/dev/userfaultfd` path. As a result, the test fails on `main` and subsequent PRs (#57) because the Github actions job runs as the user `runner` which doesn't have access to read/write `/dev/userfaultfd`.

This PR fixes this situation doing two things:
1. It runs the tests both in `ubuntu-latest`, with kernel 6.2 and `ubuntu-20.04`, with kernel 5.15 to exercise both paths.
2. In the case of `ubuntu-latest`, we add an extra step that gives to user `runner` read/write access to `/dev/userfaultfd` file.