### PR TITLE
Fix the manpage example

### DIFF
--- a/examples/manpage.rs
+++ b/examples/manpage.rs
@@ -29,8 +29,9 @@ fn fault_handler_thread(uffd: Uffd) {
     loop {
         // See what poll() tells us about the userfaultfd
 
-        let pollfd = PollFd::new(&uffd, PollFlags::POLLIN);
-        let nready = poll(&mut [pollfd], -1).expect("poll");
+        let mut fds = [PollFd::new(&uffd, PollFlags::POLLIN)];
+        let nready = poll(&mut fds, -1).expect("poll");
+        let pollfd = fds[0];
 
         println!("\nfault_handler_thread():");
         let revents = pollfd.revents().unwrap();


### PR DESCRIPTION
I found the output of the `manpage` example regarding the `POLLIN` event quite confusing. It ought to be true. But it is false because the `pollfd` is copied mistakenly.

```shell
$ cargo run --example manpage -- 1
...

fault_handler_thread():
    poll() returns: nready = 1; POLLIN = false; POLLERR = false

...
```