### PR TITLE
Make IoctlFlags robust to unknown flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -187,8 +187,7 @@ impl UffdBuilder {
         unsafe {
             raw::api(uffd.fd, &mut api as *mut raw::uffdio_api)?;
         }
-        let supported =
-            IoctlFlags::from_bits(api.ioctls).ok_or(Error::UnrecognizedIoctls(api.ioctls))?;
+        let supported = IoctlFlags::from_bits_retain(api.ioctls);
         if !supported.contains(self.req_ioctls) {
             Err(Error::UnsupportedIoctls(supported))
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,10 +38,6 @@ pub enum Error {
     #[error("Unrecognized event in uffd_msg: {0}")]
     UnrecognizedEvent(u8),
 
-    /// An unrecognized ioctl bit was set in the result of API initialization or registration.
-    #[error("Unrecognized ioctl flags: {0}")]
-    UnrecognizedIoctls(u64),
-
     /// Requested ioctls were not available when initializing the API.
     #[error("Requested ioctls unsupported; supported: {0:?}")]
     UnsupportedIoctls(IoctlFlags),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl Uffd {
         unsafe {
             raw::register(self.as_raw_fd(), &mut register as *mut raw::uffdio_register)?;
         }
-        IoctlFlags::from_bits(register.ioctls).ok_or(Error::UnrecognizedIoctls(register.ioctls))
+        Ok(IoctlFlags::from_bits_retain(register.ioctls))
     }
 
     /// Unregister a memory address range from the userfaultfd object.
@@ -377,6 +377,9 @@ bitflags! {
         #[cfg(feature = "linux5_7")]
         const WRITE_PROTECT = 1 << raw::_UFFDIO_WRITEPROTECT;
         const API = 1 << raw::_UFFDIO_API;
+
+        /// Unknown ioctls flags are allowed to be robust to future kernel changes.
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
This is the mitigation for #61. 

Returning Error::UnrecognizedIoctls is inconvinient for developers because the only way to solve it is modifying this userfaultfd-rs crate implementation.

For example, Linux v6.6 adds UFFDIO_POISON bit to
uffdio_register.iotcls. With that change, Uffd::register() always fails even if the user don't care about the new UFFDIO_POISON feature.

We need to guard this change behind the ignore_unknown_ioctlflags feature because Error::UnrecognizedIoctls is already published and some user may depend on the error.

Using an unnamed flag for externally defined flag is originally recommended.
https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags