### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-### Unreleased
+### 0.8.0 (2024-01-12)
+
+- `IoctlFlags` accepts unknown flags (e.g. due to future kernel changes).
+  `Error::UnrecognizedIoctls` is removed.
+
+### 0.3.1 ~ 0.7.0
 
 - Added `Uffd::read_events` that can read multiple events from the userfaultfd file descriptor.
 - Updated `bitflags` dependency to `2.2.1`.


### PR DESCRIPTION
CHANGELOG.md has not been updated for a while. The stacked unreleased changes are titled as changes between 0.3.1 and 0.7.0.