### PR TITLE
Update bitflags required version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/bytecodealliance/userfaultfd-rs"
 readme = "README.md"
 
 [dependencies]
-bitflags = "2.2.1"
+bitflags = "2.4.0"
 cfg-if = "^1.0.0"
 libc = "0.2.65"
 nix = { version = "0.27", features = ["ioctl"] }


### PR DESCRIPTION
unnamed flags is supported from bitflags `2.4.0`. IoctlFlags started to use the unnamed flag from userfaultfd `0.8.0`.

This is a minor bug fix for #62 